### PR TITLE
Optimise the common case of creating a data set from n binary files

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -459,6 +459,11 @@ class Bin {
   * \brief Deep copy the bin
   */
   virtual Bin* Clone() = 0;
+
+  /*!
+  * \brief Reserve space for num_data_ data points in the bin
+  */
+  virtual void reserve(data_size_t num_data) = 0;
 };
 
 inline uint32_t BinMapper::ValueToBin(double value) const {

--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -421,9 +421,8 @@ class Bin {
   /*!
   * \brief Copy the data from other to this bin
   * \param other: The bin to copy from, must be the same type as this bin.
-  * TODO: Implement for all subclasses
   */
-  virtual void Merge(const Bin* other){}
+  virtual void Merge(const Bin* other) = 0;
 
   /*!
   * \brief Create object for bin data of one feature, will call CreateDenseBin or CreateSparseBin according to "is_sparse"

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -363,6 +363,17 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
 LIGHTGBM_C_EXPORT int LGBM_DatasetAddDataFrom(DatasetHandle target,
 					      DatasetHandle source);
 
+/*!
+* \brief Concatenate data sets from n binary files
+* \param filenames pointer to an array of filenames
+* \param n the number of data files to work on
+* \param out Dataset pointer to write to
+* \return 0 when succeed, -1 when failure happens
+*/
+LIGHTGBM_C_EXPORT int LGBM_DatasetConcatenate(const char** filenames,
+					      int n,
+					      DatasetHandle* out);
+
 // --- start Booster interfaces
 
 /*!

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -590,6 +590,9 @@ class Dataset {
   void addFeaturesFrom(Dataset* other);
   void addDataFrom(Dataset* other);
 
+  /*! \brief Reserve space in feature group bins for num_data data points */
+  void reserve(data_size_t num_data);
+
  private:
   std::string data_filename_;
   /*! \brief Store used features */

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -201,6 +201,7 @@ class Metadata {
   */
   inline int64_t num_init_score() const { return num_init_score_; }
 
+  void reserve(data_size_t num_data);
   void Merge(const Metadata& other);
 
   /*! \brief Disable copy */

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -23,12 +23,12 @@ class DatasetLoader {
     int** sample_indices, int num_col, const int* num_per_col,
     size_t total_sample_size, data_size_t num_data);
 
+  LIGHTGBM_EXPORT Dataset* LoadFromBinFiles(const char** filenames, int n);
+
   /*! \brief Disable copy */
   DatasetLoader& operator=(const DatasetLoader&) = delete;
   /*! \brief Disable copy */
   DatasetLoader(const DatasetLoader&) = delete;
-
-  data_size_t LoadNumDataFromBinFile(const char* data_filename);
 
  private:
   Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
@@ -53,6 +53,9 @@ class DatasetLoader {
 
   /*! \brief Check can load from binary file */
   std::string CheckCanLoadFromBin(const char* filename);
+
+  /*! \brief Read the number of data points from the binary file given, or return -1 on error. */
+  data_size_t LoadNumDataFromBinFile(const char* data_filename);
 
   const Config& config_;
   /*! \brief Random generator*/

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -28,6 +28,8 @@ class DatasetLoader {
   /*! \brief Disable copy */
   DatasetLoader(const DatasetLoader&) = delete;
 
+  data_size_t LoadNumDataFromBinFile(const char* data_filename);
+
  private:
   Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
 

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -230,6 +230,11 @@ class FeatureGroup {
     bin_data_.reset(other.bin_data_->Clone());
   }
 
+  /*! \brief Reserve space for num_data data points */
+  void reserve(data_size_t num_data){
+    bin_data_->reserve(num_data);
+  }
+
  private:
   /*! \brief Number of features */
   int num_feature_;

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -796,6 +796,14 @@ class Dataset(object):
                 c_str(params_str),
                 ref_dataset,
                 ctypes.byref(self.handle)))
+        elif isinstance(data, list) and len(data) > 0 and all(isinstance(x, string_type) for x in data):
+            strs = (ctypes.c_char_p * len(data))()
+            for i, x in enumerate(data):
+                strs[i] = c_str(data[i])
+            self.handle = ctypes.c_void_p()
+            _safe_call(_LIB.LGBM_DatasetConcatenate(strs,
+                                                    len(data),
+                                                    ctypes.byref(self.handle)))
         elif isinstance(data, scipy.sparse.csr_matrix):
             self.__init_from_csr(data, params_str, ref_dataset)
         elif isinstance(data, scipy.sparse.csc_matrix):

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -916,18 +916,7 @@ int LGBM_DatasetConcatenate(const char** filenames,
   }
   Config config;
   DatasetLoader loader(config, nullptr, 1, nullptr);
-  Dataset* ret = loader.LoadFromFile(filenames[0], nullptr);
-  data_size_t total_data = ret->num_data();
-  for(int i = 1; i < n; i++){
-    total_data += loader.LoadNumDataFromBinFile(filenames[i]);
-  }
-  ret->reserve(total_data);
-  for(int i = 1; i < n; i++){
-    Dataset* next = loader.LoadFromFile(filenames[i], nullptr);
-    ret->addDataFrom(next);
-    delete next;
-  }
-  *out = ret;
+  *out = loader.LoadFromBinFiles(filenames, n);
   API_END();
 }
 // ---- start of booster

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -907,7 +907,29 @@ int LGBM_DatasetAddDataFrom(DatasetHandle target,
   API_END();
 }
 
-
+int LGBM_DatasetConcatenate(const char** filenames,
+			    int n,
+			    DatasetHandle* out){
+  API_BEGIN();
+  if(n < 1){
+    throw std::runtime_error("DatasetConcatenate requires at least 1 dataset to concatenate.");
+  }
+  Config config;
+  DatasetLoader loader(config, nullptr, 1, nullptr);
+  Dataset* ret = loader.LoadFromFile(filenames[0], nullptr);
+  data_size_t total_data = ret->num_data();
+  for(int i = 1; i < n; i++){
+    total_data += loader.LoadNumDataFromBinFile(filenames[i]);
+  }
+  ret->reserve(total_data);
+  for(int i = 1; i < n; i++){
+    Dataset* next = loader.LoadFromFile(filenames[i], nullptr);
+    ret->addDataFrom(next);
+    delete next;
+  }
+  *out = ret;
+  API_END();
+}
 // ---- start of booster
 
 int LGBM_BoosterCreate(const DatasetHandle train_data,

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -1026,4 +1026,10 @@ void Dataset::addDataFrom(Dataset* other){
   num_data_ += other->num_data_;
 }
 
+void Dataset::reserve(data_size_t num_data){
+  for(auto& fg: feature_groups_){
+    fg->reserve(num_data);
+  }
+}
+
 }  // namespace LightGBM

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -1027,6 +1027,7 @@ void Dataset::addDataFrom(Dataset* other){
 }
 
 void Dataset::reserve(data_size_t num_data){
+  metadata_.reserve(num_data);
   for(auto& fg: feature_groups_){
     fg->reserve(num_data);
   }

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -1142,4 +1142,17 @@ std::string DatasetLoader::CheckCanLoadFromBin(const char* filename) {
   }
 }
 
+data_size_t DatasetLoader::LoadNumDataFromBinFile(const char* bin_filename){
+  auto reader = VirtualFileReader::Make(bin_filename);
+  if(!reader->Init()){
+    Log::Fatal("Could not read binary data from %s", bin_filename);
+  }
+  size_t size_of_token = std::strlen(Dataset::binary_file_token);
+  size_t buffer_size = size_of_token + sizeof(size_t) + sizeof(data_size_t);
+  auto buffer = std::vector<char>(buffer_size);
+  reader->Read(buffer.data(), buffer_size);
+  auto mem_ptr = buffer.data()+size_of_token+sizeof(size_t);
+  return *(reinterpret_cast<data_size_t*>(mem_ptr));
+}
+
 }  // namespace LightGBM

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -5,6 +5,7 @@
 #include <LightGBM/utils/array_args.h>
 
 #include <LightGBM/network.h>
+#include <cstdlib>
 
 
 namespace LightGBM {
@@ -273,7 +274,7 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
 
   // buffer to read binary file
   size_t buffer_size = 16 * 1024 * 1024;
-  auto buffer = (char*)malloc(sizeof(char)*buffer_size);
+  auto buffer = (char*)std::malloc(sizeof(char)*buffer_size);
 
   // check token
   size_t size_of_token = std::strlen(Dataset::binary_file_token);
@@ -297,8 +298,8 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   // re-allocmate space if not enough
   if (size_of_head > buffer_size) {
     buffer_size = size_of_head;
-    free(buffer);
-    buffer = (char*)malloc(buffer_size);
+    std::free(buffer);
+    buffer = (char*)std::malloc(buffer_size);
   }
   // read header
   read_cnt = reader->Read(buffer, size_of_head);
@@ -451,8 +452,8 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   // re-allocate space if not enough
   if (size_of_metadata > buffer_size) {
     buffer_size = size_of_metadata;
-    free(buffer);
-    buffer = (char*)malloc(buffer_size);
+    std::free(buffer);
+    buffer = (char*)std::malloc(buffer_size);
   }
   //  read meta data
   read_cnt = reader->Read(buffer, size_of_metadata);
@@ -512,8 +513,8 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     // re-allocate space if not enough
     if (size_of_feature > buffer_size) {
       buffer_size = size_of_feature;
-      free(buffer);
-      buffer = (char*)malloc(buffer_size);
+      std::free(buffer);
+      buffer = (char*)std::malloc(buffer_size);
     }
 
     read_cnt = reader->Read(buffer, size_of_feature);
@@ -528,6 +529,7 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   }
   dataset->feature_groups_.shrink_to_fit();
   dataset->is_finish_load_ = true;
+  std::free(buffer);
   return dataset.release();
 }
 

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -290,9 +290,7 @@ class DenseBin: public Bin {
         data_[i] = mem_data[local_used_indices[i]];
       }
     } else {
-      for (int i = 0; i < num_data_; ++i) {
-        data_[i] = mem_data[i];
-      }
+      memcpy(data_.data(), mem_data, sizeof(VAL_T)*num_data_);
     }
   }
 
@@ -314,9 +312,7 @@ class DenseBin: public Bin {
   void Merge(const Bin* other){
     auto other_bin = dynamic_cast<const DenseBin<VAL_T>*>(other);
     data_.reserve(num_data_+other_bin->num_data_);
-    for(int i = 0; i < other_bin->num_data_; i++){
-      data_.push_back(other_bin->data_[i]);
-    }
+    data_.insert(data_.end(), other_bin->data_.begin(), other_bin->data_.end());
     num_data_ += other_bin->num_data_;
   }
 

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -322,6 +322,10 @@ class DenseBin: public Bin {
 
  DenseBin<VAL_T>* Clone() override;
 
+ void reserve(data_size_t num_data){
+   data_.reserve(num_data);
+ }
+
  private:
   data_size_t num_data_;
   std::vector<VAL_T> data_;

--- a/src/io/dense_nbits_bin.hpp
+++ b/src/io/dense_nbits_bin.hpp
@@ -385,6 +385,10 @@ class Dense4bitsBin : public Bin {
 
   Dense4bitsBin* Clone() override;
 
+  void reserve(data_size_t num_data){
+    data_.reserve((num_data+1)/2);
+  }
+
  protected:
   Dense4bitsBin(const Dense4bitsBin& other)
     : num_data_(other.num_data_), data_(other.data_), buf_(other.buf_){}

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -530,6 +530,13 @@ size_t Metadata::SizesInByte() const  {
   return size;
 }
 
+void Metadata::reserve(data_size_t num_data){
+  label_.reserve(num_data);
+  if(weights() != nullptr){
+    weights_.reserve(num_data);
+  }
+}
+
 void Metadata::Merge(const Metadata& other){
   label_.reserve(num_data_+other.num_data_);
   label_.insert(label_.end(), other.label_.begin(), other.label_.end());

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -432,6 +432,8 @@ class SparseBin: public Bin {
 
   SparseBin<VAL_T>* Clone() override;
 
+  void reserve(data_size_t num_data){}
+
  protected:
   SparseBin<VAL_T>(const SparseBin<VAL_T>& other)
     : num_data_(other.num_data_), deltas_(other.deltas_), vals_(other.vals_),

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -432,7 +432,7 @@ class SparseBin: public Bin {
 
   SparseBin<VAL_T>* Clone() override;
 
-  void reserve(data_size_t num_data){}
+  void reserve(data_size_t num_data){(void)num_data;}
 
  protected:
   SparseBin<VAL_T>(const SparseBin<VAL_T>& other)


### PR DESCRIPTION
Previously, this would use a quadratic algorithm due to repeatedly resizing the underlying data bins.
The new implementation scans the binary file headers to work out the bin size required, which allows it to resize up front in one go.